### PR TITLE
Add plugin name to readme

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,4 +1,4 @@
-=== Plugin Name ===
+=== Genesis Featured Widget Amplified ===
 Contributors: Nick_theGeek
 Donate link: https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=RGUXZDAKT7BDW
 Tags: genesis, genesiswp, studiopress, featured post, custom post type, pagination


### PR DESCRIPTION
Without this, it fails at https://wordpress.org/plugins/developers/readme-validator/